### PR TITLE
Ensuring UTF-8 encoding, added wrapper for windows

### DIFF
--- a/PANELIZER.BAT
+++ b/PANELIZER.BAT
@@ -5,4 +5,5 @@ REM
 PATH="c:\Program Files\KiCad\bin";%PATH%
 echo %~dp0
 
+python --version
 python %~dp0\panelizer.py %*

--- a/PANELIZER.BAT
+++ b/PANELIZER.BAT
@@ -1,0 +1,8 @@
+@echo OFF
+REM
+REM WRAPPER FOR WINDOWS INCLUDING THE PYTHON PATH FROM KICAD ITSELF
+REM
+PATH="c:\Program Files\KiCad\bin";%PATH%
+echo %~dp0
+
+python %~dp0\panelizer.py %*

--- a/panelizer.py
+++ b/panelizer.py
@@ -13,6 +13,10 @@ Original author: Willem Hillier
 
 __version__ = '1.5'
 
+reload(sys)
+sys.setdefaultencoding("utf-8")
+
+
 # set up command-line arguments parser
 parser = ArgumentParser(description="A script to panelize KiCad files.")
 parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)

--- a/panelizer.py
+++ b/panelizer.py
@@ -13,8 +13,9 @@ Original author: Willem Hillier
 
 __version__ = '1.5.1'
 
-reload(sys)
-sys.setdefaultencoding("utf-8")
+if sys.version_info[0] == 2:
+  reload(sys)
+  sys.setdefaultencoding("utf-8")
 
 
 # set up command-line arguments parser

--- a/panelizer.py
+++ b/panelizer.py
@@ -11,7 +11,7 @@ A simple script to create a v-scored panel of a KiCad board.
 Original author: Willem Hillier
 """
 
-__version__ = '1.5'
+__version__ = '1.5.1'
 
 reload(sys)
 sys.setdefaultencoding("utf-8")


### PR DESCRIPTION
When text in the title sheet is UTF-8 encoded, the script fails.  That is fixed by chaning the defaultencoding.

To simplify running on windows, a PANELIZER.BAT wrapper is proposed.